### PR TITLE
Add a Docker based development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/php-7
+{
+	"name": "phpDvdProfiler",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service":"app",
+	"workspaceFolder": "/var/www",
+	"shutdownAction": "stopCompose",
+	// Use 'settings' to set *default* container specific settings.json values on container create.
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/sh"
+	},
+
+	// Use 'appPort' to create a container with published ports. If the port isn't working, be sure
+	// your server accepts connections from all interfaces (0.0.0.0 or '*'), not just localhost.
+	"appPort": ["8080:80"],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "php -v",
+
+	// Uncomment the next line to have VS Code connect as an existing non-root user in the container.
+	// On Linux, by default, the container user's UID/GID will be updated to match your local user. See
+	// https://aka.ms/vscode-remote/containers/non-root for details on adding a non-root user if none exist.
+	// "remoteUser": "vscode",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"felixfbecker.php-debug",
+		"felixfbecker.php-intellisense"
+	]
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+docker-compose*.yml
+.dockerignore
+.git
+.gitignore
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=3306
+DB_DATABASE=phpdvdprofiler
+DB_USERNAME=admin
+DB_PASSWORD=admin

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ DB_PORT=3306
 DB_DATABASE=phpdvdprofiler
 DB_USERNAME=admin
 DB_PASSWORD=admin
+# remote_host should be set to host.internal.docker when running
+# via docker-compose, but localhost when running from VSCode remote containers
+XDEBUG_CONFIG="remote_host=localhost remote_port=9229 remote_enable=1"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sonar-project.properties
 localsiteconfig.php*
 *.xml
 *.xml.gz
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9229,
+            "log": false
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ RUN curl -sS https://getcomposer.org/installer | php \
         && mv composer.phar /usr/local/bin/ \
         && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
 
+RUN apk add --no-cache --virtual build-dependencies $PHPIZE_DEPS \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del build-dependencies
+
 COPY . /var/www/
 
 WORKDIR /var/www/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM php:7.2-fpm-alpine
+
+RUN apk update && apk upgrade \
+    && apk add --no-cache \
+        freetype \
+        libpng \
+        libjpeg-turbo \
+        freetype-dev \
+        libpng-dev \
+        jpeg-dev \
+        libjpeg \
+        libjpeg-turbo-dev \
+     && docker-php-ext-configure gd \
+        --with-freetype-dir=/usr/include/ \
+        --with-jpeg-dir=/usr/include/ \
+        --with-png-dir=/usr/include/ \
+     && docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) gd \
+     && docker-php-ext-install mysqli iconv mbstring \
+     && rm -rf /tmp/* /var/cache/apk/*
+RUN curl -sS https://getcomposer.org/installer | php \
+        && mv composer.phar /usr/local/bin/ \
+        && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
+
+COPY . /var/www/
+
+WORKDIR /var/www/
+RUN cp contrib/docker/php.ini /usr/local/etc/php/conf.d/phpdvdprofiler.ini
+
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+ENV PATH="~/.composer/vendor/bin:./vendor/bin:${PATH}"
+
+CMD exec php-fpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM php:7.2-fpm-alpine
 
 RUN apk update && apk upgrade \
+    && apk add gnu-libiconv --no-cache \
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+        --allow-untrusted \
     && apk add --no-cache \
         freetype \
         libpng \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apk update && apk upgrade \
         jpeg-dev \
         libjpeg \
         libjpeg-turbo-dev \
+        git \
      && docker-php-ext-configure gd \
         --with-freetype-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+DOCKER_COMPOSE  = docker-compose
+EXEC_PHP        = $(DOCKER_COMPOSE) run --rm -T php
+
+build:
+	@$(DOCKER_COMPOSE) pull --parallel --quiet --ignore-pull-failures 2> /dev/null
+	$(DOCKER_COMPOSE) build --pull
+
+kill:
+	$(DOCKER_COMPOSE) kill
+	$(DOCKER_COMPOSE) down --volumes --remove-orphans
+
+install: ## Install and start the project
+install: .env build start
+
+reset: ## Stop and start a fresh install of the project
+reset: kill install
+
+start: ## Start the project
+	$(DOCKER_COMPOSE) up -d --remove-orphans --no-recreate
+
+stop: ## Stop the project
+	$(DOCKER_COMPOSE) stop
+
+clean: ## Stop the project and remove generated files
+clean: kill
+	rm -rf .env vendor
+
+.PHONY: build kill install reset start stop clean
+
+.env: .env.example
+	@if [ -f .env ]; \
+	then\
+		echo '\033[1;41m/!\ The .env.example file has changed. Please check your .env file (this message will not be displayed again).\033[0m';\
+		touch .env;\
+		exit 1;\
+	else\
+		echo cp .env.example .env;\
+		cp .env.example .env;\
+	fi
+
+.DEFAULT_GOAL := help
+help:
+	@grep -E '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
+.PHONY: help

--- a/contrib/docker/nginx.conf
+++ b/contrib/docker/nginx.conf
@@ -1,0 +1,32 @@
+upstream php-upstream {
+    server app:9000;
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server ipv6only=on;
+
+    server_name localhost;
+    root /var/www;
+    index index.php;
+
+    # location / {
+    #     try_files $uri $uri/ /index.php?$query_string;
+    # }
+
+    location ~ \.php$ {
+        try_files $uri /index.php =404;
+        fastcgi_pass php-upstream;
+        fastcgi_index index.php;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        #fixes timeouts
+        fastcgi_read_timeout 600;
+        include fastcgi_params;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/contrib/docker/php.ini
+++ b/contrib/docker/php.ini
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 128M
+upload_max_filesize = 64M
+post_max_size = 64M
+max_execution_time = 600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.3'
+
+services:
+  web:
+    image: nginx:alpine
+    volumes:
+      - ./contrib/docker/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./:/var/www
+    networks:
+     - internal
+     - external
+    depends_on:
+      - app
+    ports:
+      - "8080:80"
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - ./.env
+    volumes:
+      - ./:/var/www
+    networks:
+      - external
+      - internal
+  db:
+    image: mysql:5.6
+    restart: unless-stopped
+    env_file:
+      - ./.env
+    networks:
+      - internal
+      - external
+    # command: --default-authentication-plugin=mysql_native_password
+    environment:
+      - MYSQL_DATABASE=phpdvdprofiler
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+    volumes:
+      - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql
+      - "db-data:/var/lib/mysql"
+    ports:
+      - '3306:3306'
+
+volumes:
+  db-data:
+  app-storage:
+
+networks:
+  internal:
+    internal: true
+  external:
+    driver: bridge


### PR DESCRIPTION
Whilst this works, and is what I have been running locally, it is not *quite* ready to go into master yet; I still need to rebase and split out the commits. However I thought I would push this up as a draft to allow people to raise comment/suggestions.

I've used alpine as the container as it is lightweight and produces a nice small image and is generally really good for this application. The main error that comes up at the moment is:

```
Notice: iconv(): Wrong charset, conversion from `ISO-8859-1' to `ascii//TRANSLIT' is not allowed in /var/www/functions.php on line 1033

Warning: Cannot modify header information - headers already sent by (output started at /var/www/functions.php:1033) in /var/www/index.php on line 2884
```
I know why the first one errs and the second one can be ignored as it only displays because of the first. At the moment it doesn't stop anything from working. I may switch alpine out for debian if it proves a pain

I've added a Makefile for convenience, I realise that a Powershell file may need to be included too (or indeed a VSCode .devcontainer) for those running windows, but I've had no chance to write/test one. 

When you first clone the  project and run `make install` it will 
1) copy the env.example file to .env
2)Build the docker containers. unless you have deleted the image, it has changed,  or you have run `reset` this will only happen the first time and will be quite slow.
3) start all the containers in the background.

From here all you need to do is visit the webpage via port 8080, upload your Collection.XML via the usual method and then everything is ready to go. You can edit your PHP files locally and the changes will be reflected.

during development you _should_ not have to run `make install` again, just use `make start` and `make stop`

MySQL will automatically create the database, and run schema.sql to set-up the required structure once the container has been started.

If you don't want to, or can't run the Makefile then you can run the steps manually:

1) docker pull --parallel 
2) docker build --no-cache --pull  (the pull here makes sure you have the latest base image and won't use the local one if it exists)
3) docker-compose up
4) profit

On a side note, as part of another patch series/MR I would like introduce a standard Collection.xml fixture into the database to use for development. I have one that I used locally when developing #2. This contains a few Blu-Rays and UltraHD titles; However, if we add a DVD, HD-DVD, as well as a release or two in non-english languages we should have enough to make sure nothing is breaking :-)

**note: If you would like to test this out, in your localsiteconfig.php file set `$dbhost = 'db';`**

_this wall of text will be cleaned up into something more cohesive before it is taken out of draft_
