### PR TITLE
PHP 8 compatibility fixes

### DIFF
--- a/Chooser.php
+++ b/Chooser.php
@@ -185,8 +185,8 @@ EOT;
 		for ($i=0; $i<=strlen($PossibleRegions); $i++) {
 			$currentRegion = substr($PossibleRegions, $i, 1);
 			if (!empty($currentRegion) && strpos($rgnlist, $currentRegion) !== false) {
-				$val = $PossibleRegions{$i};
-				$disp = $PossibleRegions{$i};
+				$val = $PossibleRegions[$i];
+				$disp = $PossibleRegions[$i];
 				if ($val == '0') $disp = $lang['ALLREGIONSDVD'];
 				if ($val == '@') $disp = $lang['ALLREGIONSBLURAY'];
 				$regioncombo .= "<option value=\"$val\">$disp</option>";

--- a/Picker.php
+++ b/Picker.php
@@ -9,7 +9,7 @@ global $getimages, $img_webpathf, $thumbnails;
 
 	if ($getimages > 0) {
 		if ($getimages == 3) {
-			$thumbs = "<img alt=\"\" width=60 height=84 src=\"{$img_webpathf}$thumbnails/{$id}f.jpg\">";
+			$thumbs = "<img alt=\"\" width=60 height=84 src=\"{$img_webpathf}$thumbnails/[$id]f.jpg\">";
 		}
 		else {
 			$thumbs = '<img alt="" width=60 height=84 src="' . resize_jpg($id, 'f', 60, 100) . '">';

--- a/checktables.php
+++ b/checktables.php
@@ -28,7 +28,7 @@ function DisplayAResultSet(&$db, $sql) {
 }
 
 	$table = @$_GET['table'];
-	if ($table{0} == '$')
+	if ($table[0] == '$')
 		$table = $GLOBALS[substr($table, 1)];
 	if ($table == '')
 		$table = $DVD_STATS_TABLE;

--- a/global.php
+++ b/global.php
@@ -8,10 +8,6 @@ ini_set('error_reporting', E_ALL);
 ini_set('log_errors', 1);
 ini_set('error_log', 'ERROR_LOG');
 
-// removeme
-define('IN_SCRIPT', 1);
-// ---
-
 if (!defined('IN_SCRIPT')) {
 	die('This script should not be manually executed ... Possible Hacking attempt');
 }

--- a/global.php
+++ b/global.php
@@ -33,19 +33,6 @@ $EGPCS = array(
 		'_GET'
 		);
 
-#if (get_magic_quotes_gpc()) {
-if (False) {
-function StripMagicQuotes(&$var) {
-	if (is_array($var)) {
-		foreach ($var as $k=>$v)
-			StripMagicQuotes($var[$k]);
-		return;
-	}
-	$var = stripslashes($var);
-}
-	foreach ($EGPCS as $k => $v)
-		StripMagicQuotes($$v);
-}
 @extract($_POST);
 @extract($_GET);
 

--- a/global.php
+++ b/global.php
@@ -8,6 +8,10 @@ ini_set('error_reporting', E_ALL);
 ini_set('log_errors', 1);
 ini_set('error_log', 'ERROR_LOG');
 
+// removeme
+define('IN_SCRIPT', 1);
+// ---
+
 if (!defined('IN_SCRIPT')) {
 	die('This script should not be manually executed ... Possible Hacking attempt');
 }
@@ -33,6 +37,19 @@ $EGPCS = array(
 		'_GET'
 		);
 
+#if (get_magic_quotes_gpc()) {
+if (False) {
+function StripMagicQuotes(&$var) {
+	if (is_array($var)) {
+		foreach ($var as $k=>$v)
+			StripMagicQuotes($var[$k]);
+		return;
+	}
+	$var = stripslashes($var);
+}
+	foreach ($EGPCS as $k => $v)
+		StripMagicQuotes($$v);
+}
 @extract($_POST);
 @extract($_GET);
 

--- a/incupdate.php
+++ b/incupdate.php
@@ -2187,8 +2187,8 @@ global $audiospecialcondition, $Highlight_Last_X_PurchaseDates, $UpdateLast, $My
 // Profile totals per region (ie. number of discs playable in region 2)
 	for ($i=0; $i<strlen($PossibleRegions); $i++) {
 		DoSomeStats('Region', false,
-			"'".$PossibleRegions{$i}."','','',COUNT(*) AS total FROM $DVD_TABLE ",
-			"WHERE region LIKE '%".$PossibleRegions{$i}."%' AND collectiontype='owned' $regionspecialcondition",
+			"'".$PossibleRegions[$i]."','','',COUNT(*) AS total FROM $DVD_TABLE ",
+			"WHERE region LIKE '%".$PossibleRegions[$i]."%' AND collectiontype='owned' $regionspecialcondition",
 			'',
 			$noadulttitles, $ProfileName, $Profile, $numtimings, $t0);
 	}

--- a/incupdate.php
+++ b/incupdate.php
@@ -348,7 +348,7 @@ global $inbrowser, $lang, $WorkAroundLibxmlBug, $HTMLEntSearch, $HTMLEntReplace;
 		$start = $where_exactly - $amt_on_either_side;
 		if ($start < 0) $start = 0;
 		echo hexdump(substr($data, $start, $where_exactly-$start), $where_exactly-$start, '     ');
-		echo hexdump($data{$where_exactly}, 1, '===> ');
+		echo hexdump($data[$where_exactly], 1, '===> ');
 		echo hexdump(substr($data, $where_exactly+1, $amt_on_either_side), $amt_on_either_side, '     ');
 		echo $lang['IMPORTBADXML5'];
 		if ($inbrowser) {

--- a/index.php
+++ b/index.php
@@ -5,7 +5,6 @@ define('IN_SCRIPT', 1);
 include_once('version.php');
 include_once('global.php');
 
-
 function UpdateDataRow(&$dvd) {
 	$dvd['primegenre'] = GenreTranslation($dvd['primegenre']);
 	FormatTheTitle($dvd);
@@ -1914,6 +1913,7 @@ if ($action == 'show') {
 		exit;
 	}
 	$result = $db->sql_query("SELECT * FROM $DVD_TABLE WHERE id='".$db->sql_escape($mediaid)."' LIMIT 1") or die($db->sql_error());
+
 	$dvd = $db->sql_fetchrow($result);
 	$db->sql_freeresult($result);
 	if ($dvd) {
@@ -2097,6 +2097,7 @@ if ($action == 'show') {
 		}
 		unset($credit);
 		$db->sql_freeresult($result);
+
 		$IMDBNum = array();
 // Make list of discs - ajm
 		$result = $db->sql_query("SELECT * FROM $DVD_DISCS_TABLE WHERE id='".$db->sql_escape($mediaid)."' ORDER BY discno ASC") or die($db->sql_error());
@@ -2160,6 +2161,7 @@ if ($action == 'show') {
 		$db->sql_freeresult($result);
 		if ($locval == ', ')
 			$locval = '';
+
 // Make list of events - ajm
 		$dvd['p_events'] = '';
 		$dvd['events'] = array();
@@ -2195,6 +2197,7 @@ if ($action == 'show') {
 		$locks['features'] = $locks['subtitles'] = $locks['eastereggs'] = $locks['runningtime'] = '';
 		$locks['releasedate'] = $locks['productionyear'] = $locks['casetype'] = $locks['videoformats'] = '';
 		$locks['rating'] = $locks['mediatype'] = '';
+
 		if (DisplayIfIsPrivateOrAlways($searchlocks)) {
 // Make list of locks - ajm
 			$result = $db->sql_query("SELECT * FROM $DVD_LOCKS_TABLE WHERE id='".$db->sql_escape($mediaid)."'") or die($db->sql_error());
@@ -2277,6 +2280,7 @@ if ($action == 'show') {
 		unset($subtitle);
 		$db->sql_freeresult($result);
 		if ($dvd['p_subtitles'] == '') $dvd['p_subtitles'] = '&nbsp;';
+
 // Make list of studios
 		$dvd['p_studios'] = '';
 		$ps = $mc = '';
@@ -2342,6 +2346,7 @@ if ($action == 'show') {
 			if (strpos($colours, ',') !== false) $colours = "($colours)";
 		}
 		$dvd['format'] .= ' ' . $colours;
+
 		$dynamicRange = (($dvd['drhdr10']==1)	? '(' . $dynamicrange_translation['HDR10'] . ')' : '')
 			. (($dvd['drdolbyvision']==1) ? '(' . $dynamicrange_translation['DOLBYVISION'] . ')' : '');
 
@@ -2384,6 +2389,7 @@ if ($action == 'show') {
 		$dvd['media'] = (($dvd['formatdualsided']==1)  ? $lang['DUALSIDED']: $lang['SINGLESIDED'])
 			. (($dvd['formatduallayered']==1)      ? ", $lang[DUALLAYERED]": ", $lang[SINGLELAYERED]");
 		$dvd['media'] = preg_replace('/^, /', '', $dvd['media']);
+
 		$dvd['p_extras'] = (($dvd['featuresceneaccess']==1)	? ", $lang[SCENEACCESS]": '')
 			. ((isset($dvd['featureplayall']) && $dvd['featureplayall']==1)		? ", $lang[PLAYALL]": '')
 			. (($dvd['featuretrailer']==1)			? ", $lang[TRAILER]": '')
@@ -2615,8 +2621,8 @@ if ($action == 'show') {
 				$regions .= "<img height=\"17px\" src=\"gfx/region_".substr($dvd['region'], $i, 1).".gif\" style=\"vertical-align:-30%; margin-bottom:2px\" title=\"$lang[REGION] ".substr($dvd['region'], $i, 1)."\" alt=\"\"/>\n";
 			}
 		}
-		$db->sql_freeresult($result);
 
+		$db->sql_freeresult($result);
 		$dvd['p_casetype'] = $lang[strtoupper(str_replace(' ', '', $dvd['casetype']))];
 		if ($dvd['caseslipcover'] != 0)
 			$dvd['p_casetype'] .= ", $lang[SLIPCOVER]";

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ define('IN_SCRIPT', 1);
 include_once('version.php');
 include_once('global.php');
 
+
 function UpdateDataRow(&$dvd) {
 	$dvd['primegenre'] = GenreTranslation($dvd['primegenre']);
 	FormatTheTitle($dvd);
@@ -388,7 +389,7 @@ function IsValidReviewString($review) {
 	if (strlen($review) > 4)
 		return(false);
 	for ($i=0; $i<strlen($review); $i++) {
-		if (strpos('FVAE', $review{$i}) === false)
+		if (strpos('FVAE', $review[$i]) === false)
 			return(false);
 	}
 	return(true);
@@ -400,7 +401,7 @@ global $ReviewLabels;
 	$sort = '';
 	if (IsValidReviewString($review)) {
 		for ($i=0; $i<strlen($review); $i++) {
-			$sort .= $ReviewLabels[$review{$i}] . " $order,";
+			$sort .= $ReviewLabels[$review[$i]] . " $order,";
 		}
 	}
 	$sort .= 'sorttitle ASC';
@@ -414,7 +415,7 @@ global $lang, $ReviewLabels;
 		return($lang['BADREVIEWSTRING'].$review);
 	$title = '';
 	for ($i=0; $i<strlen($review); $i++)
-		$title .= FormatLabel(FixAReviewValue($dvd[$ReviewLabels[$review{$i}]])/2, $lang['REVIEWNAMES'][$review{$i}], $short);
+		$title .= FormatLabel(FixAReviewValue($dvd[$ReviewLabels[$review[$i]]])/2, $lang['REVIEWNAMES'][$review[$i]], $short);
 
 	if (substr($title, -1, 1) == ' ')
 		$title = substr($title, 0, -1);
@@ -445,12 +446,12 @@ global $lang, $ReviewLabels;
 
 	$rest = $width;
 	for ($j=0; $j<strlen($review); $j++) {
-		$m = FixAReviewValue($dvd[$ReviewLabels[$review{$j}]]);
+		$m = FixAReviewValue($dvd[$ReviewLabels[$review[$j]]]);
 		$rest -= $WidthOfOne*$m;
 		$nm = floor($m/2); $rm = $m - $nm*2;
 		for ($i=0; $i<$nm; $i++)
-			$ret .= '<TD WIDTH='. (2*$WidthOfOne-1) .' BGCOLOR="'.$bincolors[$review{$j}].'"></TD>';
-		if ($rm != 0) $ret .= '<TD WIDTH='. ($WidthOfOne-1) .' BGCOLOR="'.$bincolors[$review{$j}].'"></TD>';
+			$ret .= '<TD WIDTH='. (2*$WidthOfOne-1) .' BGCOLOR="'.$bincolors[$review[$j]].'"></TD>';
+		if ($rm != 0) $ret .= '<TD WIDTH='. ($WidthOfOne-1) .' BGCOLOR="'.$bincolors[$review[$j]].'"></TD>';
 	}
 
 	$ret .= "<TD WIDTH=$rest>";
@@ -508,7 +509,7 @@ global $colnorange, $lang, $order, $reviewsort;
 	switch ($sort) {
 	case 'sorttitle':
 		if ($dvd['sorttitle'] != '')
-			$sepa = strtolower($dvd['sorttitle']{0});
+			$sepa = strtolower($dvd['sorttitle'][0]);
 		else
 			$sepa = '';
 		if (preg_match("/\d/", $sepa)) {
@@ -1269,7 +1270,7 @@ $srchtext = $db->sql_escape($srchtext);
 switch ($searchby) {
 case 'title':
 // Add the ability to anchor search to the start of the field
-	if ($srchtext{0} == '^')
+	if ($srchtext[0] == '^')
 		$where .= " AND (dvd.title LIKE '".substr($srchtext,1)."%' OR originaltitle LIKE '".substr($srchtext,1)."%' OR description LIKE '".substr($srchtext,1)."%')";
 	else
 		$where .= " AND (dvd.title LIKE '%$srchtext%' OR originaltitle LIKE '%$srchtext%' OR description LIKE '%$srchtext%')";
@@ -1455,7 +1456,7 @@ if ($action == 'main') {
   $rssfeed
   <script type="text/javascript" src="top.js"></script>
 </head>
-<frameset id="thecols" cols="$widthgt800,*" $nomove>
+<frameset id="thecols" cols="$widthgt800,*" $nomove bordercolor=$ClassColor[1]>
   <frameset id="therows" rows="*,1" border=0 frameborder=0 framespacing=0>
     <frame src="$PHP_SELF?sort=$sort&amp;order=$order&amp;collection=$collection&amp;searchby=$searchby&amp;searchtext=$searchurl&amp;action=nav" name="nav" scrolling=no framespacing=0 marginheight=2 marginwidth=2>
     <frame src="$PHP_SELF?sort=$sort&amp;order=$order&amp;collection=$collection&amp;searchby=$searchby&amp;searchtext=$searchurl&amp;action=menu" name="menu" scrolling=yes framespacing=0 marginheight=0 marginwidth=0>
@@ -1913,7 +1914,6 @@ if ($action == 'show') {
 		exit;
 	}
 	$result = $db->sql_query("SELECT * FROM $DVD_TABLE WHERE id='".$db->sql_escape($mediaid)."' LIMIT 1") or die($db->sql_error());
-
 	$dvd = $db->sql_fetchrow($result);
 	$db->sql_freeresult($result);
 	if ($dvd) {
@@ -2097,7 +2097,6 @@ if ($action == 'show') {
 		}
 		unset($credit);
 		$db->sql_freeresult($result);
-
 		$IMDBNum = array();
 // Make list of discs - ajm
 		$result = $db->sql_query("SELECT * FROM $DVD_DISCS_TABLE WHERE id='".$db->sql_escape($mediaid)."' ORDER BY discno ASC") or die($db->sql_error());
@@ -2161,7 +2160,6 @@ if ($action == 'show') {
 		$db->sql_freeresult($result);
 		if ($locval == ', ')
 			$locval = '';
-
 // Make list of events - ajm
 		$dvd['p_events'] = '';
 		$dvd['events'] = array();
@@ -2197,7 +2195,6 @@ if ($action == 'show') {
 		$locks['features'] = $locks['subtitles'] = $locks['eastereggs'] = $locks['runningtime'] = '';
 		$locks['releasedate'] = $locks['productionyear'] = $locks['casetype'] = $locks['videoformats'] = '';
 		$locks['rating'] = $locks['mediatype'] = '';
-
 		if (DisplayIfIsPrivateOrAlways($searchlocks)) {
 // Make list of locks - ajm
 			$result = $db->sql_query("SELECT * FROM $DVD_LOCKS_TABLE WHERE id='".$db->sql_escape($mediaid)."'") or die($db->sql_error());
@@ -2280,7 +2277,6 @@ if ($action == 'show') {
 		unset($subtitle);
 		$db->sql_freeresult($result);
 		if ($dvd['p_subtitles'] == '') $dvd['p_subtitles'] = '&nbsp;';
-
 // Make list of studios
 		$dvd['p_studios'] = '';
 		$ps = $mc = '';
@@ -2346,7 +2342,6 @@ if ($action == 'show') {
 			if (strpos($colours, ',') !== false) $colours = "($colours)";
 		}
 		$dvd['format'] .= ' ' . $colours;
-
 		$dynamicRange = (($dvd['drhdr10']==1)	? '(' . $dynamicrange_translation['HDR10'] . ')' : '')
 			. (($dvd['drdolbyvision']==1) ? '(' . $dynamicrange_translation['DOLBYVISION'] . ')' : '');
 
@@ -2389,7 +2384,6 @@ if ($action == 'show') {
 		$dvd['media'] = (($dvd['formatdualsided']==1)  ? $lang['DUALSIDED']: $lang['SINGLESIDED'])
 			. (($dvd['formatduallayered']==1)      ? ", $lang[DUALLAYERED]": ", $lang[SINGLELAYERED]");
 		$dvd['media'] = preg_replace('/^, /', '', $dvd['media']);
-
 		$dvd['p_extras'] = (($dvd['featuresceneaccess']==1)	? ", $lang[SCENEACCESS]": '')
 			. ((isset($dvd['featureplayall']) && $dvd['featureplayall']==1)		? ", $lang[PLAYALL]": '')
 			. (($dvd['featuretrailer']==1)			? ", $lang[TRAILER]": '')
@@ -2621,8 +2615,8 @@ if ($action == 'show') {
 				$regions .= "<img height=\"17px\" src=\"gfx/region_".substr($dvd['region'], $i, 1).".gif\" style=\"vertical-align:-30%; margin-bottom:2px\" title=\"$lang[REGION] ".substr($dvd['region'], $i, 1)."\" alt=\"\"/>\n";
 			}
 		}
-
 		$db->sql_freeresult($result);
+
 		$dvd['p_casetype'] = $lang[strtoupper(str_replace(' ', '', $dvd['casetype']))];
 		if ($dvd['caseslipcover'] != 0)
 			$dvd['p_casetype'] .= ", $lang[SLIPCOVER]";
@@ -2943,7 +2937,7 @@ var item=document.getElementById(theitems);
 </tr>
 </table>
 
-<table class=bgl width="100%">
+<table class=bgd width="100%">
 <tr>
 <td valign=top class=bgd width="100%" rowspan=2>
 <table width="100%" cellpadding=0>

--- a/index.php
+++ b/index.php
@@ -1455,7 +1455,7 @@ if ($action == 'main') {
   $rssfeed
   <script type="text/javascript" src="top.js"></script>
 </head>
-<frameset id="thecols" cols="$widthgt800,*" $nomove bordercolor=$ClassColor[1]>
+<frameset id="thecols" cols="$widthgt800,*" $nomove>
   <frameset id="therows" rows="*,1" border=0 frameborder=0 framespacing=0>
     <frame src="$PHP_SELF?sort=$sort&amp;order=$order&amp;collection=$collection&amp;searchby=$searchby&amp;searchtext=$searchurl&amp;action=nav" name="nav" scrolling=no framespacing=0 marginheight=2 marginwidth=2>
     <frame src="$PHP_SELF?sort=$sort&amp;order=$order&amp;collection=$collection&amp;searchby=$searchby&amp;searchtext=$searchurl&amp;action=menu" name="menu" scrolling=yes framespacing=0 marginheight=0 marginwidth=0>
@@ -2943,7 +2943,7 @@ var item=document.getElementById(theitems);
 </tr>
 </table>
 
-<table class=bgd width="100%">
+<table class=bgl width="100%">
 <tr>
 <td valign=top class=bgd width="100%" rowspan=2>
 <table width="100%" cellpadding=0>

--- a/mysqli.php
+++ b/mysqli.php
@@ -423,7 +423,8 @@ class sql_db
 		{
 			$query_id = $this->query_result;
 		}
-		if ($query_id) {
+		if ($query_id && isset($query_id->num_rows))
+		{
 			@mysqli_free_result($query_id);
 			return true;
 		} else {

--- a/mysqli.php
+++ b/mysqli.php
@@ -417,7 +417,7 @@ class sql_db
 		return ($this->db_connect_id) ? @mysqli_insert_id($this->db_connect_id) : false;
 	}
 
-	function sql_freeresult($query_id = false) 
+	function sql_freeresult($query_id = false)
 	{
 		if (!$query_id)
 		{

--- a/mysqli.php
+++ b/mysqli.php
@@ -417,14 +417,13 @@ class sql_db
 		return ($this->db_connect_id) ? @mysqli_insert_id($this->db_connect_id) : false;
 	}
 
-	function sql_freeresult($query_id = false)
+	function sql_freeresult($query_id = false) 
 	{
 		if (!$query_id)
 		{
 			$query_id = $this->query_result;
 		}
-		if ($query_id && isset($query_id->num_rows))
-		{
+		if ($query_id && isset($query_id->num_rows)) {
 			@mysqli_free_result($query_id);
 			return true;
 		} else {

--- a/processskin.php
+++ b/processskin.php
@@ -754,7 +754,7 @@ global $dvd;
 	$ret = $prefix;
 	for ($i=0; $i<strlen($dvd['region']); $i++) {
 		if ($ret != '') $ret .= ', ';
-		$ret .= $dvd['region']{$i};
+		$ret .= $dvd['region'][$i];
 	}
 	return($ret);
 }

--- a/statistics.php
+++ b/statistics.php
@@ -1,5 +1,5 @@
 <?php
-/*	$Id: statistics.php,v 1.1 2005/02/06 14:31:55 fred Exp $	*/
+/*	$Id$	*/
 
 function MakeAPercentage($value, $total, $decimals=0) {
 	if ($total == 0)

--- a/userpref.php
+++ b/userpref.php
@@ -1,5 +1,5 @@
 <?php
-/*	$Id: userpref.php,v 1.0 2005/01/01 14:31:55 fred Exp $	*/
+/*	$Id$	*/
 
 define('IN_SCRIPT', 1);
 include_once('version.php');

--- a/ws.php
+++ b/ws.php
@@ -986,7 +986,7 @@ global $db, $DVD_TABLE, $DVD_EVENTS_TABLE, $DVD_USERS_TABLE, $lang, $watched, $h
 
 	$rs = $times+1;
 	if ($getimages == 3)
-		$thumbname = "$img_webpath{$id}f.jpg";
+		$thumbname = "$img_webpath[$id]f.jpg";
 	else
 		$thumbname = PhyspathToWebpath(resize_jpg($id, "f", 60, 100));
 


### PR DESCRIPTION
Hi,
I fixed the array indexing from `$array{i}`-style to `$array[i]` in all the places I could find.
Also, the sql_freeresult() function in mysqli.php caused the script to break when called on an already freed query_id (as it happens in info.php).
Not sure why the Id:-lines in userprefs.php and statistics.php get stripped when pushing - they are still present in my local code.